### PR TITLE
Fix error in `ApiConnection#disconnect`

### DIFF
--- a/lib/adp/api_connection.rb
+++ b/lib/adp/api_connection.rb
@@ -35,7 +35,7 @@ module Adp
         end
 
         def disconnect
-            self.access_token = null;
+            self.access_token = nil
         end
 
         # @return [Boolean]

--- a/spec/adp/api_connection_spec.rb
+++ b/spec/adp/api_connection_spec.rb
@@ -3,8 +3,16 @@ require 'rspec'
 
 
 describe 'Adp::Connection::ApiConnection::' do
+  subject { Adp::Connection::ApiConnection.new }
 
   it 'should initialize ApiConnection' do
     expect(Adp::Connection::ApiConnection.new).not_to be nil
+  end
+
+  it 'should set set the access_token to nil on disconnect' do
+    subject.access_token = 'set_token'
+    subject.disconnect
+
+    expect(subject.access_token).to be(nil)
   end
 end


### PR DESCRIPTION
The keyword `null` is not defined in Ruby, use `nil` instead. Include a spec to test to verify that `access_token` is properly nil'd after calling `disconnect`. Additionally, remove unneeded semi-colon.