### PR TITLE
Fix missing sslCaPath error

### DIFF
--- a/lib/adp/api_connection.rb
+++ b/lib/adp/api_connection.rb
@@ -139,6 +139,9 @@ module Adp
                 http.cert = OpenSSL::X509::Certificate.new( pem );
                 http.key = OpenSSL::PKey::RSA.new(key, self.connection_configuration.sslKeyPass);
                 http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+            end
+
+            if (!self.connection_configuration.sslCaPath.nil?)
                 http.cert_store = OpenSSL::X509::Store.new
                 http.cert_store.add_file(self.connection_configuration.sslCaPath)
             end

--- a/lib/adp/authorization_code_connection.rb
+++ b/lib/adp/authorization_code_connection.rb
@@ -39,7 +39,7 @@ module Adp
             :state => self.state
         )
 
-        Log.debug("URL was #{url}")
+        log("URL was #{url}")
         return url
       end
 
@@ -69,7 +69,7 @@ module Adp
           end
         end
 
-        Log.debug("connection configutration: #{self.connection_configuration.inspect}")
+        log("connection configutration: #{self.connection_configuration.inspect}")
 
         data = {
             "client_id" => self.connection_configuration.clientID,
@@ -88,9 +88,17 @@ module Adp
           raise ConnectionException, "Connection error: #{result["error"]} #{result['error_description']}"
         end
 
-        Log.debug("Results from request was #{result}");
+        log("Results from request was #{result}");
 
         token
+      end
+
+      private
+
+      def log(message)
+        logger = Logger.new(STDOUT)
+        logger.level = Logger::DEBUG
+        logger.debug(message)
       end
     end
   end


### PR DESCRIPTION
Not really sure what sslCaPath is and our project is working just fine without it so maybe only load it if it exist? Also saw some forks that just remove this line:

```
http.cert_store = OpenSSL::X509::Store.new
http.cert_store.add_file(self.connection_configuration.sslCaPath)
```
Related issue thats been ignored: https://github.com/adplabs/adp-connection-ruby/issues/9

You also missed some Log errors on `lib/adp/authorization_code_connection.rb`.
Related: https://github.com/adplabs/adp-connection-ruby/pull/5