### PR TITLE
hotfix/Add sslCaPath only if it is present

### DIFF
--- a/lib/adp/api_connection.rb
+++ b/lib/adp/api_connection.rb
@@ -139,6 +139,9 @@ module Adp
                 http.cert = OpenSSL::X509::Certificate.new( pem );
                 http.key = OpenSSL::PKey::RSA.new(key, self.connection_configuration.sslKeyPass);
                 http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+            end
+
+            if (!self.connection_configuration.sslCaPath.nil?)
                 http.cert_store = OpenSSL::X509::Store.new
                 http.cert_store.add_file(self.connection_configuration.sslCaPath)
             end


### PR DESCRIPTION
Add `sslCAPath` to cert store only if path is present. 