### PR TITLE
Don't require specific version of json gem

### DIFF
--- a/adp-connection.gemspec
+++ b/adp-connection.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   # spec.add_dependency "uri"
   # spec.add_dependency "net/https"
   # spec.add_dependency "base64"
-  spec.add_dependency "json", '~> 1.8'
+  spec.add_dependency "json"
   # spec.add_dependency 'securerandom'
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
Doing so is making it hard to upgrade to ruby 2.7. See https://github.com/flori/json/issues/399